### PR TITLE
Add Rotation Lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,10 @@ A: Just press 'F2'
 Q: How can I taunt? <-- MUST TRY! 
 A: Just press 'F3' when in prop mode. 
 
-Q: I don't know ho this works! 
+Q: How do i lock where my prop is facing?
+A: Just press 'R' when looking at the direction you like when in prop mode. 
+
+Q: I don't know how this works! 
 A: Check out the discussion "Help for Newer Players." by "☾ ILikeStargates ٣٩٤#" 
 
 Q: There are error symbols and purple-black checkerboard .-. 
@@ -55,16 +58,16 @@ Just fill this form: {COLLEGAMENTO RIMOSSO} - If you can, please give a log.
 ## WANT TO CONTRIBUTE? ##
 Help us to find to fix all bugs! 
 Fork our Git repo: 
-https://bitbucket.org/xspacesoft/prophunt-hidenseek-original
+https://github.com/kowalski7cc/prophunt-hidenseek-original
 
 ## CREDITS: ##
-Credit goes for the original authors of both gamemodes and who made Prop Hunt compatible with GMOD 13. 
-Originally written and released by Darkimmortal (TF2) 
-Originally ported to GMod: AMT 
-Fixed for GMod 13: Leleudk 
-Enhanced an published: Me
+Credit goes to the original authors of the gamemodes and those who made Prop Hunt compatible with GMOD 13.
+Originally written and released by Darkimmortal on Team Fortress 2 (TF2)
+Originally ported to GMod: AMT
+First fix for GMod 13: LeleuDK
+Enhanced, fixed, and published: Kowalski7cc
 Various Contributors:
-- MrLuckyGamer 
+- MrLuckyGamer (FRETTA fix & Rotation Lock)
 Thanks also who help answering people on the page :D 
 
 If you are the author or if you have credit, and you don’t to see this mod on the Workshop anymore... just contact me 

--- a/gamemodes/prop_hunt/gamemode/cl_init.lua
+++ b/gamemodes/prop_hunt/gamemode/cl_init.lua
@@ -1,4 +1,5 @@
 include("sh_init.lua")
+include("rotation_lock.lua")
 
 -- Decides where  the player view should be (forces third person for props)
 function GM:CalcView(pl, origin, angles, fov)

--- a/gamemodes/prop_hunt/gamemode/init.lua
+++ b/gamemodes/prop_hunt/gamemode/init.lua
@@ -3,6 +3,7 @@ AddCSLuaFile("cl_init.lua")
 AddCSLuaFile("sh_config.lua")
 AddCSLuaFile("sh_init.lua")
 AddCSLuaFile("sh_player.lua")
+AddCSLuaFile("rotation_lock.lua")
 
 
 -- If there is a mapfile send it to the client (sometimes servers want to change settings for certain maps)
@@ -13,6 +14,7 @@ end
 
 -- Include the required lua files
 include("sh_init.lua")
+include("rotation_lock.lua")
 
 
 -- Server only constants

--- a/gamemodes/prop_hunt/gamemode/rotation_lock.lua
+++ b/gamemodes/prop_hunt/gamemode/rotation_lock.lua
@@ -1,0 +1,100 @@
+AddCSLuaFile()
+
+-- ConVar
+if !ConVarExists("ph_rotation_support") then
+    local ph_rotation_support = CreateConVar(
+        "ph_rotation_support",
+        "1",
+        {FCVAR_ARCHIVE, FCVAR_REPLICATED, FCVAR_NOTIFY}
+    )
+end
+
+if SERVER then
+
+    -- Player spawns
+    local function PROPHUNTROTHOOK_PlayerSpawn(pl)
+        if GetConVar("ph_rotation_support"):GetBool() && pl:Team() == TEAM_PROPS then
+            pl.lockRotation = false
+            pl.usesNewRotation = false
+            
+            timer.Simple(0.1, function() 
+                if IsValid(pl) then 
+                    PROPHUNTROT_PostPlayerSpawn(pl) 
+                end 
+            end)
+        end
+    end
+    hook.Add("PlayerSpawn", "PROPHUNTROTHOOK_PlayerSpawn", PROPHUNTROTHOOK_PlayerSpawn)
+
+    -- Think hook for updating prop angles/position
+    local function PROPHUNTROTHOOK_Think()
+        if !GetConVar("ph_rotation_support"):GetBool() then return end
+
+        for _, pl in pairs(team.GetPlayers(TEAM_PROPS)) do
+            if not pl:IsValid() or not pl:Alive() or not pl.usesNewRotation then continue end
+            local prop = pl.ph_prop
+            if not prop or not prop:IsValid() then continue end
+
+            -- Update position
+            if prop:GetModel() == "models/player/kleiner.mdl" then
+                prop:SetPos(pl:GetPos())
+            else
+                prop:SetPos(pl:GetPos() - Vector(0,0,prop:OBBMins().z))
+            end
+
+            -- Update angles (always upright)
+            local ang = prop:GetAngles()
+            ang.pitch = 0
+            ang.roll = 0
+
+            if not pl.lockRotation then
+                ang.yaw = pl:EyeAngles().yaw -- update yaw only when unlocked
+            end
+
+            prop:SetAngles(ang)
+
+            -- Check R key for toggling lock
+            if pl:KeyPressed(IN_RELOAD) then
+                pl.lockRotation = not pl.lockRotation
+                pl:ChatPrint("Locked Rotation: "..string.upper(tostring(pl.lockRotation)))
+            end
+        end
+    end
+    hook.Add("Think", "PROPHUNTROTHOOK_Think", PROPHUNTROTHOOK_Think)
+
+    -- Post player spawn setup
+    function PROPHUNTROT_PostPlayerSpawn(pl)
+        local prop = pl.ph_prop
+        if not pl:Alive() or not prop or not prop:IsValid() then return end
+
+        if prop:GetParent() and prop:GetParent():IsValid() then
+            prop:SetParent(nil)
+        end
+
+        pl.usesNewRotation = true
+        pl:ChatPrint("Press the reload button to lock your rotation.")
+    end
+
+    -- ConVar change callback
+    local function PROPHUNTROT_RotationSupportChanged(name, old, new)
+        PrintMessage(HUD_PRINTTALK, "Warning: ph_rotation_support changed. Bugs may occur!")
+
+        for _, pl in pairs(team.GetPlayers(TEAM_PROPS)) do
+            local prop = pl.ph_prop
+            if not pl:IsValid() or not pl:Alive() or not prop or not prop:IsValid() then continue end
+
+            if pl.usesNewRotation then
+                pl.lockRotation = false
+                pl.usesNewRotation = false
+                prop:SetParent(pl)
+            else
+                if prop:GetParent() and prop:GetParent():IsValid() then
+                    prop:SetParent(nil)
+                end
+                pl.usesNewRotation = true
+                pl:ChatPrint("Press the reload button to lock your rotation.")
+            end
+        end
+    end
+    cvars.AddChangeCallback("ph_rotation_support", PROPHUNTROT_RotationSupportChanged)
+end

--- a/gamemodes/prop_hunt/gamemode/sh_init.lua
+++ b/gamemodes/prop_hunt/gamemode/sh_init.lua
@@ -27,7 +27,9 @@ As a Prop you have ]]..HUNTER_BLINDLOCK_TIME..[[ seconds to replicate an existin
 
 As a Hunter you will be blindfolded for the first ]]..HUNTER_BLINDLOCK_TIME..[[ seconds of the round while the Props hide. When your blindfold is taken off, you will need to find props controlled by players and kill them. Damaging non-player props will lower your health significantly. However, killing a Prop will increase your health by ]]..HUNTER_KILL_BONUS..[[ points.
 
-Both teams can press [F3] to play a taunt sound.]]
+Both teams can press [F3] to play a taunt sound.
+
+Props can press [R] to lock their rotation.]]
 
 
 -- Fretta configuration

--- a/gamemodes/prop_hunt/prop_hunt.txt
+++ b/gamemodes/prop_hunt/prop_hunt.txt
@@ -42,5 +42,14 @@
 			"type"		"CheckBox"
 			"default"	"1"
 		}
+
+		4
+        {
+            "name"      "PH_ROTATION_SUPPORT"
+            "text"      "Enable Rotation Lock"
+            "help"      "Allows props to lock their rotation with the reload key"
+            "type"      "CheckBox"
+            "default"   "1"
+        }
 	}
 }


### PR DESCRIPTION
Added rotation lock for props team.

Players can now press R as a prop to lock there props direction it is facing.

Prop model is now properly locked rather then going by eye angle.

Added ph_rotation_support ConVar (set to 1 (enabled) by default).

Updated readme and other text for Rotation lock.